### PR TITLE
add order and order_items table, add ability to view past orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,6 @@
+class OrdersController < ApplicationController
+  def index
+    @user = current_user
+    @orders = @user.orders
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,9 @@
+class Order < ActiveRecord::Base
+  belongs_to :user
+  has_many :order_items
+  has_many :items, through: :order_items
+
+  validates :user, presence: :true
+  validates :items, presence: :true
+  validates :status, presence: :true
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,7 @@
+class OrderItem < ActiveRecord::Base
+  belongs_to :item
+  belongs_to :order
+
+  validates :item, presence: :true
+  validates :order, presence: :true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ActiveRecord::Base
 
   after_create :set_default_role
 
+  has_many :orders
+
   validates :username, presence: true
   validates :password_digest, presence: true
   validates :email, presence: true

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,10 @@
+<h1>Your Orders</h1>
+<div>
+  <div class="container">
+    <ul>
+    <% @orders.each do |order| %>
+      <li>Order Number: <%= order.id %> <%= link_to "View Order", order_path(order) %> </li>
+    <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:index]
 
+  resources :orders, only: [:index, :show]
+
   get '/dashboard', to: 'users#show'
 
   get '/login', to: 'sessions#new'

--- a/db/migrate/20160611182449_create_orders.rb
+++ b/db/migrate/20160611182449_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration
+  def change
+    create_table :orders do |t|
+      t.string :status
+      t.references :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160611183557_create_order_items.rb
+++ b/db/migrate/20160611183557_create_order_items.rb
@@ -1,0 +1,11 @@
+class CreateOrderItems < ActiveRecord::Migration
+  def change
+    create_table :order_items do |t|
+      t.references :item, index: true, foreign_key: true
+      t.references :order, index: true, foreign_key: true
+      t.integer :quantity
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160608213512) do
+ActiveRecord::Schema.define(version: 20160611183557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,26 @@ ActiveRecord::Schema.define(version: 20160608213512) do
 
   add_index "items", ["category_id"], name: "index_items_on_category_id", using: :btree
 
+  create_table "order_items", force: :cascade do |t|
+    t.integer  "item_id"
+    t.integer  "order_id"
+    t.integer  "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "order_items", ["item_id"], name: "index_order_items_on_item_id", using: :btree
+  add_index "order_items", ["order_id"], name: "index_order_items_on_order_id", using: :btree
+
+  create_table "orders", force: :cascade do |t|
+    t.string   "status"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "username"
     t.string   "password_digest"
@@ -45,4 +65,7 @@ ActiveRecord::Schema.define(version: 20160608213512) do
   end
 
   add_foreign_key "items", "categories"
+  add_foreign_key "order_items", "items"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "orders", "users"
 end

--- a/spec/features/user_views_past_orders_spec.rb
+++ b/spec/features/user_views_past_orders_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature "user views past orders" do
+  let(:order_instance_1) { create(:order) }
+  let(:order_instance_2) { create(:order) }
+
+  scenario "authenticated user views past orders" do
+    user = order_instance_1.user
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(user)
+    visit "/orders"
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -20,5 +20,4 @@ RSpec.describe Category, type: :model do
   describe "category validates associations" do
     it { expect(category_instance).to have_many(:items) }
   end
-
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Item, type: :model do
   end
 
   context "item should have the correct attributes" do
-    it { should respond_to(:title) }
-    it { should respond_to(:price) }
-    it { should respond_to(:description) }
-    it { should respond_to(:image_path) }
-    it { should respond_to(:category) }
+    it { expect(item_instance).to respond_to(:title) }
+    it { expect(item_instance).to respond_to(:price) }
+    it { expect(item_instance).to respond_to(:description) }
+    it { expect(item_instance).to respond_to(:image_path) }
+    it { expect(item_instance).to respond_to(:category) }
   end
 
   describe "can be created using a factory" do
@@ -35,5 +35,4 @@ RSpec.describe Item, type: :model do
  
   describe "item validates associations" do 
   end
-
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe OrderItem, type: :model do
-
   let(:order_item_instance) { build(:order_item) }
 
   it "has a valid factory" do
     expect(order_item_instance).to be_valid
   end
- 
+
   describe "has correct attributes" do
     it { expect(order_item_instance).to respond_to(:order) }
     it { expect(order_item_instance).to respond_to(:item) }
@@ -18,7 +17,7 @@ RSpec.describe OrderItem, type: :model do
     it { expect(order_item_instance).to belong_to(:item) }
   end
 
-  describe "item validates attributes" do 
+  describe "item validates attributes" do
     it { expect(order_item_instance).to validate_presence_of(:order) }
     it { expect(order_item_instance).to validate_presence_of(:item) }
   end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+
+  let(:order_item_instance) { build(:order_item) }
+
+  it "has a valid factory" do
+    expect(order_item_instance).to be_valid
+  end
+ 
+  describe "has correct attributes" do
+    it { expect(order_item_instance).to respond_to(:order) }
+    it { expect(order_item_instance).to respond_to(:item) }
+  end
+
+  describe "category validates associations" do
+    it { expect(order_item_instance).to belong_to(:order) }
+    it { expect(order_item_instance).to belong_to(:item) }
+  end
+
+  describe "item validates attributes" do 
+    it { expect(order_item_instance).to validate_presence_of(:order) }
+    it { expect(order_item_instance).to validate_presence_of(:item) }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-
   let(:order_instance) { build(:order) }
 
   it "has a valid factory" do
     expect(order_instance).to be_valid
   end
-  
+
   describe "order should have the correct attributes" do
     it { should respond_to(:user) }
     it { should respond_to(:status) }
@@ -21,8 +20,8 @@ RSpec.describe Order, type: :model do
     it { expect(order_instance).to have_many(:items) }
   end
 
-  describe "order validates attributes" do 
-     it { expect(order_instance).to validate_presence_of(:status) }
-     it { expect(order_instance).to validate_presence_of(:user) }
+  describe "order validates attributes" do
+    it { expect(order_instance).to validate_presence_of(:status) }
+    it { expect(order_instance).to validate_presence_of(:user) }
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+
+  let(:order_instance) { build(:order) }
+
+  it "has a valid factory" do
+    expect(order_instance).to be_valid
+  end
+  
+  describe "order should have the correct attributes" do
+    it { should respond_to(:user) }
+    it { should respond_to(:status) }
+    it { should respond_to(:items) }
+    it { should respond_to(:order_items) }
+  end
+
+  describe "order has correct associations" do
+    it { expect(order_instance).to belong_to(:user) }
+    it { expect(order_instance).to have_many(:order_items) }
+    it { expect(order_instance).to have_many(:items) }
+  end
+
+  describe "order validates attributes" do 
+     it { expect(order_instance).to validate_presence_of(:status) }
+     it { expect(order_instance).to validate_presence_of(:user) }
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -30,4 +30,15 @@ FactoryGirl.define do
     email "email"
     role "0"
   end
+
+  factory :order do
+    user
+    status "ready"
+    items { create_list(:item, 3) }
+  end
+
+  factory :order_item do
+    order
+    item
+  end
 end


### PR DESCRIPTION
closes #31 
- setup new tables (order and order_items)
  - generate model for order and order_items with correct associations
  - migrate tables
  - add model tests for Order and OrderItem
- create factories for order and order_item
- change Rspec syntax in item_spec from 'should' to 'expect'
- add validations for order
  - add validations in Order model
  - adjust factory for Order
